### PR TITLE
docs: change Open Banking URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 ### Work
 
-I manage the Developer Relations team working on [open banking APIs](https://banno.com/digital-toolkit/) at [Jack Henry](https://jackhenry.dev).
+I manage the Developer Relations team working on [open banking APIs](https://www.jackhenry.com/what-we-offer/digital-banking/open-banking-platform-integration) at [Jack Henry](https://jackhenry.dev).
 
 ### Conference Talks
 


### PR DESCRIPTION
The newer URL (post rebranding) is a nicer one to use for this than the older style from the previous URL.